### PR TITLE
修复输出文本内容时会在文本内容前多输出一个空格的bug

### DIFF
--- a/lib/print-element.js
+++ b/lib/print-element.js
@@ -85,10 +85,11 @@ var printRawTextElementNode = function(info, node, condition, opt){
 var printNormalElementNode = function(info, node, condition, opt){
     var content = (
         condition.newLine ?
-        info.children.filter(function(child){
-            return child.trim()
-        }).map(function(child){
-            return info.innerIndent + child;
+        info.children.map(function(child){
+            child = child.trim();
+            return child ? (info.innerIndent + child) : child;
+        }).filter(function(child){
+            return child;
         }) :
         info.children
     ).join(info.sep);


### PR DESCRIPTION
bug表现:

``` html
<p>
    test
</p>
```

会输出

``` html
<p>
     test
</p>
```
